### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-@cdavernas
-@jbbianchi
+* @cdavernas @jbbianchi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @cdavernas @jbbianchi
+* @cdavernas @jbbianchi @asyncapi-bot-eve


### PR DESCRIPTION
you need `*` to indicate the scope (like all) of the ownership. Also codeowners for given scope should be in one line